### PR TITLE
Bump dependencies and fix import usage (<>) for GHC 8.4.*; fix RE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,19 @@ where `<lhs>` and `<rhs>` are arbitrary Haskell expressions. cyp supports plain 
 
 keyword and followed by one or two lists of equations:
 
-      <term a1>
-      .=. <term a2>
-      .=. <...>
-      .=. <term an>
+                     <term a1>
+  (by <reason>)  .=. <term a2>
+                  .
+                  .
+                  .
+  (by <reason>)  .=. <term an>
 
-      <term b1>
-      .=. <term b1>
-      .=. <...>
-      .=. <term bn>
+                     <term b1>
+  (by <reason>)  .=. <term b2>
+                  .
+                  .
+                  .
+  (by <reason>)  .=. <term bn>
 
 Each term must be given on a separate line and be indented by at least one space. If two lists are given, they are handled as if the second list was reversed and appended to the first. An equational proof is accepted if
 

--- a/cyp.cabal
+++ b/cyp.cabal
@@ -19,16 +19,16 @@ library
     , Test.Info2.Cyp.Util
   build-depends:
       base ==4.*
-    , containers ==0.5.*
+    , containers ==0.6.*
     , directory ==1.3.*
     , filepath ==1.4.*
     , haskell-src-exts ==1.21.*
     , mtl ==2.2.*
     , parsec ==3.1.*
     , pretty ==1.1.*
-    , pretty-show ==1.6.*
+    , pretty-show ==1.9.*
     , tagged ==0.8.*
-    , tasty ==0.12.*
+    , tasty ==1.2.*
 
 executable cyp
   main-is:           Main.hs
@@ -48,4 +48,4 @@ test-suite test
   build-depends:
       base ==4.*
     , cyp
-    , tasty ==0.12.*
+    , tasty ==1.2.*

--- a/cyp.cabal
+++ b/cyp.cabal
@@ -22,13 +22,13 @@ library
     , containers ==0.5.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , haskell-src-exts ==1.18.*
+    , haskell-src-exts ==1.21.*
     , mtl ==2.2.*
     , parsec ==3.1.*
     , pretty ==1.1.*
     , pretty-show ==1.6.*
     , tagged ==0.8.*
-    , tasty ==0.11.*
+    , tasty ==0.12.*
 
 executable cyp
   main-is:           Main.hs
@@ -48,4 +48,4 @@ test-suite test
   build-depends:
       base ==4.*
     , cyp
-    , tasty ==0.11.*
+    , tasty ==0.12.*

--- a/cyp.cabal
+++ b/cyp.cabal
@@ -19,16 +19,16 @@ library
     , Test.Info2.Cyp.Util
   build-depends:
       base ==4.*
-    , containers ==0.6.*
+    , containers ==0.5.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , haskell-src-exts ==1.21.*
+    , haskell-src-exts ==1.20.*
     , mtl ==2.2.*
     , parsec ==3.1.*
     , pretty ==1.1.*
-    , pretty-show ==1.9.*
+    , pretty-show ==1.7.*
     , tagged ==0.8.*
-    , tasty ==1.2.*
+    , tasty ==1.1.*
 
 executable cyp
   main-is:           Main.hs
@@ -48,4 +48,4 @@ test-suite test
   build-depends:
       base ==4.*
     , cyp
-    , tasty ==1.2.*
+    , tasty ==1.1.*

--- a/src/Test/Info2/Cyp.hs
+++ b/src/Test/Info2/Cyp.hs
@@ -60,7 +60,7 @@ checkProofs env (l : ls) = do
     checkProofs env' ls
 
 checkLemma :: ParseLemma -> Env -> Err (Prop, Env)
-checkLemma (ParseLemma name rprop proof) env = errCtxt (text "Lemma" <+> text name <> colon <+> unparseRawProp rprop) $ do
+checkLemma (ParseLemma name rprop proof) env = errCtxt (text "Lemma" <+> text name Text.PrettyPrint.<> colon <+> unparseRawProp rprop) $ do
     let (prop, env') = declareProp rprop env
     Prop _ _ <- checkProof prop proof env'
     let proved = generalizeEnvProp env prop
@@ -214,7 +214,7 @@ checkProof prop (ParseCases dtRaw onRaw casesRaw) env = errCtxt ctxtMsg $ do
 validDatatype :: String -> Env -> Err DataType
 validDatatype name env = case find (\dt -> dtName dt == name) (datatypes env) of
     Nothing -> err $ fsep $
-        [ text "Invalid datatype" <+> quotes (text name) <> text "."
+        [ text "Invalid datatype" <+> quotes (text name) Text.PrettyPrint.<> text "."
         , text "Expected one of:" ]
         ++ punctuate comma (map (quotes . text . dtName) $ datatypes env)
     Just dt -> Right dt
@@ -240,7 +240,7 @@ validConsCase t (DataType _ conss) = errCtxt invCaseMsg $ do
         Just x -> return x
     findCons _ = errStr "Outermost symbol is not a constant"
 
-    invCaseMsg = text "Invalid case" <+> quotes (unparseTerm t) <> comma
+    invCaseMsg = text "Invalid case" <+> quotes (unparseTerm t) Text.PrettyPrint.<> comma
 
 validEqnSeq :: [Named Prop] -> EqnSeq Term -> Err Prop
 validEqnSeq _ (Single t) = return (Prop t t)
@@ -250,7 +250,7 @@ validEqnSeq rules (Step t1 rule es)
         return (Prop t1 tLast)
     | otherwise = errCtxtStr ("Invalid proof step" ++ noRuleMsg) $ err $
         unparseTerm t1 $+$ text ("(by " ++ rule ++ ") " ++ symPropEq) <+> unparseTerm t2
-        $+$ debug (text rule <> text ":" <+> vcat (map (unparseProp . namedVal) $ filter (\x -> namedName x == rule) rules))
+        $+$ debug (text rule Text.PrettyPrint.<> text ":" <+> vcat (map (unparseProp . namedVal) $ filter (\x -> namedName x == rule) rules))
   where
     (t2, _) = eqnSeqEnds es
     noRuleMsg

--- a/src/Test/Info2/Cyp/Util.hs
+++ b/src/Test/Info2/Cyp/Util.hs
@@ -13,7 +13,7 @@ where
 
 import Data.Monoid (mempty)
 import Language.Haskell.Exts (SrcLoc (..), ParseResult (..))
-import Text.PrettyPrint (Doc, (<>), (<+>), ($+$), colon, empty, int, nest, text)
+import Text.PrettyPrint (Doc, (<+>), (<>), ($+$), colon, empty, int, nest, text)
 
 type Err = Either Doc
 
@@ -44,5 +44,5 @@ debug = id
 renderSrcExtsFail :: String -> ParseResult a -> Doc
 renderSrcExtsFail _ (ParseOk _) = mempty
 renderSrcExtsFail typ (ParseFailed (SrcLoc _ _ col) msg) =
-    (text "Failed to parse" <+> text typ <+> text "at position" <+> int col <> colon)
+    (text "Failed to parse" <+> text typ <+> text "at position" <+> int col Text.PrettyPrint.<> colon)
     `indent` text msg

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.16
+resolver: lts-12.26
 
 packages:
 - '.'


### PR DESCRIPTION
### What
1. Bump dependencies and fix import usage for `(<>)`
1. Import proof example in README

### Why
1. Compiling with GHC 8.4.4 returned an error as `(<>)` is now exported by Prelude.
2. README gave imprecise example - see [issue](https://github.com/noschinl/cyp/issues/19).

### How
1. Bump dependencies to newest versions

### Testing
All examples in `test-data/pos` succeed and all examples in `test-data/neg` fail.