### PR TITLE
Bump GHC version to latest stack LTS

### DIFF
--- a/cyp.cabal
+++ b/cyp.cabal
@@ -19,16 +19,16 @@ library
     , Test.Info2.Cyp.Util
   build-depends:
       base ==4.*
-    , containers ==0.5.*
+    , containers ==0.6.*
     , directory ==1.3.*
     , filepath ==1.4.*
-    , haskell-src-exts ==1.20.*
+    , haskell-src-exts ==1.23.*
     , mtl ==2.2.*
     , parsec ==3.1.*
     , pretty ==1.1.*
-    , pretty-show ==1.7.*
+    , pretty-show ==1.10.*
     , tagged ==0.8.*
-    , tasty ==1.1.*
+    , tasty ==1.4.*
 
 executable cyp
   main-is:           Main.hs
@@ -48,4 +48,4 @@ test-suite test
   build-depends:
       base ==4.*
     , cyp
-    , tasty ==1.1.*
+    , tasty ==1.4.*

--- a/src/Test/Info2/Cyp/Util.hs
+++ b/src/Test/Info2/Cyp/Util.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleInstances #-}
+
 module Test.Info2.Cyp.Util
     ( Err
     , debug
@@ -16,6 +18,9 @@ import Language.Haskell.Exts (SrcLoc (..), ParseResult (..))
 import Text.PrettyPrint (Doc, (<+>), (<>), ($+$), colon, empty, int, nest, text)
 
 type Err = Either Doc
+
+instance MonadFail (Either Doc) where
+  fail = errStr
 
 err :: Doc -> Err a
 err = Left

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,3 @@
-resolver: lts-12.26
-
 packages:
-- '.'
+- .
+resolver: lts-18.27


### PR DESCRIPTION
This allows users of Apple's M1 hardware to compile and run cyp.

Tests pass on my M1 Pro.

I've used FlexibleInstances for `instance MonadFail (Either Doc)`. I'm pretty sure that there was a sensible default implementation for `fail` before the `MonadFail` proposal, which we now have to supply. This is an ad-hoc fix since my exercise session is in about one hour ;)

Cheers,
Ben